### PR TITLE
Eliminate audible pops by perform sensor integration in parallel

### DIFF
--- a/synesthesia_organ_vibrato.ino
+++ b/synesthesia_organ_vibrato.ino
@@ -70,11 +70,6 @@ byte blueGain;
 byte indigoGain;
 byte violetGain;
 
-//timing variables. mozzi doesn't like delay()
-int sensorTimeLast;
-int sensorTimeNow;
-
-
 // use #define for CONTROL_RATE, not a constant
 #define CONTROL_RATE 64 // Hz, powers of 2 are most reliable
 

--- a/synesthesia_organ_vibrato.ino
+++ b/synesthesia_organ_vibrato.ino
@@ -94,10 +94,6 @@ void setup() {
   
   kVib.setFreq(12.5f);
   
-  sensorTimeLast = millis();
-  sensorTimeNow = millis();
-
-
   while (!Serial) {
     delay(1);
   }
@@ -115,13 +111,15 @@ void setup() {
   as7341.setATIME(100);
   as7341.setASTEP(10);
   as7341.setGain(AS7341_GAIN_256X);
+
+  // Start sensor integration.
+  as7341.startReading();
 }
 
 
 
 
 void updateControl() {
-  sensorTimeNow = millis();
 
   colorGains();
 
@@ -137,15 +135,12 @@ void updateControl() {
   indigoSin.setFreq(indigo_centre_freq+vibrato); // set the frequency
   violetSin.setFreq(violet_centre_freq+vibrato); // set the frequency
   
-  /*communicates with the sensor ten times a second
-  because I2C comms interrupts audio synthesis, this
-  is a balancing act. each communication over I2C
-  creates an audio pop. too often sounds like buzzing.
-  too infrequent means code is slow to take sensor readings*/
-  if (sensorTimeNow >= (sensorTimeLast + 100)) {
+  if (as7341.checkReadingProgress()) {
+    // Sensor integration complete, read and process sensor values.
     readSensor();
-    sensorTimeLast = millis();
 
+    // Start another round of sensor integration.
+    as7341.startReading();
   }
 
 }
@@ -176,10 +171,9 @@ AudioOutput_t updateAudio() {
 
 
 void readSensor() {
-  if (!as7341.readAllChannels()) {
-    //   Serial.println("Error reading all channels!");
-    return;
-  }
+  uint16_t readings[12];
+
+  as7341.getAllChannels(readings);
 
 
 
@@ -192,14 +186,14 @@ void readSensor() {
       current = 0;
 /*read the color channels from the sensor and write them into 
 the colorValues array for later use*/
-    colorValues[violet] = as7341.getChannel(AS7341_CHANNEL_415nm_F1);
-    colorValues[indigo] = as7341.getChannel(AS7341_CHANNEL_445nm_F2);
-    colorValues[blue] = as7341.getChannel(AS7341_CHANNEL_480nm_F3);
-    colorValues[cyan] = as7341.getChannel(AS7341_CHANNEL_515nm_F4);
-    colorValues[green] = as7341.getChannel(AS7341_CHANNEL_555nm_F5);
-    colorValues[yellow] = as7341.getChannel(AS7341_CHANNEL_590nm_F6);
-    colorValues[red] = as7341.getChannel(AS7341_CHANNEL_630nm_F7);
-    colorValues[orange] = as7341.getChannel(AS7341_CHANNEL_680nm_F8);
+    colorValues[violet] = readings[AS7341_CHANNEL_415nm_F1];
+    colorValues[indigo] = readings[AS7341_CHANNEL_445nm_F2];
+    colorValues[blue] = readings[AS7341_CHANNEL_480nm_F3];
+    colorValues[cyan] = readings[AS7341_CHANNEL_515nm_F4];
+    colorValues[green] = readings[AS7341_CHANNEL_555nm_F5];
+    colorValues[yellow] = readings[AS7341_CHANNEL_590nm_F6];
+    colorValues[red] = readings[AS7341_CHANNEL_630nm_F7];
+    colorValues[orange] = readings[AS7341_CHANNEL_680nm_F8];
 
   for (byte i = 0; i < 8; i = i + 1) {
 


### PR DESCRIPTION
Color organ sketches using `as7341.readAllChannels()` have an audio artifact every time a sensor reading is taken, because it is a blocking call that waits for sensor integration before reading sensor data and returning them. This entire procedure blocks sketch execution for long enough that Mozzi could not update audio waveform, resulting in an audible pop.

Adafruit's AS7341 library example `reading_while_looping` shows how to reduce this impact. The nonblocking call `as7341.startReading()` kicks off sensor integration and immediately returns so our sketch can continue running in parallel with sensor integration. In between Mozzi audio updates, we call `as7341.checkReadingProgress()` to check on sensor status. If it returns false, the sensor is still busy, and we continue running our sketch in parallel.

But if it returns true, the sensor integration process has completed so we can retrieve updated values via `as7341.getAllChannels()`. While this does use Arduino Wire library and hence a blocking call itself, the data is small enough and ESP32 I2C fast enough that the blocking call doesn't cause audio artifacts. (Or at least, much less noticeable ones.)